### PR TITLE
PR against 5.0: Adding Support for HA Install

### DIFF
--- a/ansible/nodes
+++ b/ansible/nodes
@@ -21,7 +21,7 @@ plugin_rpm=http://10.10.10.10/nuage-cni-k8s-0.0-7.2161.el7.centos.x86_64.rpm
 # Location of the K8S loopback CNI plugin on local host
 k8s_cni_loopback_plugin=/tmp/loopback
 # VSD user in the admin group
-vsduser=k8s-admin
+vsd_user=k8s-admin
 # Complete local path to the VSD user certificate file
 vsd_user_cert_file=/usr/local/vsd-user.pem
 # Complete local path to the VSD user key file

--- a/ansible/playbooks/deploy-cluster.yml
+++ b/ansible/playbooks/deploy-cluster.yml
@@ -3,7 +3,7 @@
 # with the default addons.
 
 - hosts: all
-  gather_facts: false
+  gather_facts: true
   become: yes
   roles:
     - pre-ansible
@@ -72,6 +72,17 @@
   serial: 1
   roles:
       - { role: nuage-master, when: networking == 'nuage' }
+  tags:
+    - network-service-install
+    - nuage
+
+# install nuage master service 
+- hosts:
+    - lb
+  become: yes
+  serial: 1
+  roles:
+      - { role: lb, when: networking == 'nuage' }
   tags:
     - network-service-install
     - nuage

--- a/ansible/roles/lb/defaults/main.yml
+++ b/ansible/roles/lb/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+haproxy_frontends:
+- name: main
+  binds:
+  - "*:{{ k8s_api_port | default(6443) }}"
+  default_backend: default
+
+haproxy_backends:
+- name: default
+  balance: roundrobin
+  servers:
+  - name: web01
+    address: 127.0.0.1:9000
+    opts: check

--- a/ansible/roles/lb/handlers/main.yml
+++ b/ansible/roles/lb/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+- name: restart haproxy
+  systemd:
+    name: haproxy
+    state: restarted
+
+- name: save iptables rules
+  command: service iptables save

--- a/ansible/roles/lb/meta/main.yml
+++ b/ansible/roles/lb/meta/main.yml
@@ -1,0 +1,11 @@
+---
+galaxy_info:
+  author: Siva Teja
+  description: haproxy loadbalancer
+  company: Nuage Networks
+  license: Apache License, Version 2.0
+  min_ansible_version: 2.2
+  platforms:
+  - name: EL
+    versions:
+    - 7

--- a/ansible/roles/lb/tasks/iptables.yml
+++ b/ansible/roles/lb/tasks/iptables.yml
@@ -1,0 +1,41 @@
+---
+- name: Install iptables packages
+  package: name={{ item }} state=present
+  with_items:
+    - iptables
+    - iptables-services
+
+- name: Start and enable iptables service
+  systemd:
+    name: iptables
+    state: started
+    enabled: yes
+    masked: no
+    daemon_reload: yes
+  register: result
+
+- name: need to pause here, otherwise the iptables service starting can sometimes cause ssh to fail
+  pause: seconds=10
+  when: result | changed
+
+
+- name: IPtables | Get iptables rules
+  command: iptables -L --wait
+  register: iptablesrules
+  always_run: yes
+
+- name: Allow listen on port for stats
+  command: /sbin/iptables -w -I INPUT 1 -p tcp --dport 9000 -j ACCEPT -m comment --comment "loadbalancer-stats"
+  when: "'loadbalancer-stats' not in iptablesrules.stdout"
+  notify: save iptables rules
+
+- name: Allow traffic to Nuage K8S Monitor
+  command: /sbin/iptables -w -I INPUT 1 -p tcp --dport {{ nuage_mon_rest_server_port | default(9443) }} -j ACCEPT -m comment --comment "nuage-monitor"
+  when: "'nuage-monitor' not in iptablesrules.stdout"
+  notify: save iptables rules
+
+- name: Allow traffic to kube API server 
+  command: /sbin/iptables -w -I INPUT 1 -p tcp --dport {{ k8s_api_port | default(6443) }} -j ACCEPT -m comment --comment "api-server-allow"
+  when: "'api-server-allow' not in iptablesrules.stdout"
+  notify: save iptables rules
+

--- a/ansible/roles/lb/tasks/main.yml
+++ b/ansible/roles/lb/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+- name: Create limits.conf directory
+  file:
+    dest: /etc/systemd/system/haproxy.service.d
+    state: directory
+    mode: 0660
+    owner: root
+    group: root
+  changed_when: false
+
+- name: Create limits.conf file
+  file:
+    dest: /etc/systemd/system/haproxy.service.d/limits.conf
+    state: touch
+    mode: 0660
+    owner: root
+    group: root
+  changed_when: false
+
+- name: Configure the nofile limits for haproxy
+  ini_file:
+    dest: /etc/systemd/system/haproxy.service.d/limits.conf
+    section: Service
+    option: LimitNOFILE
+    value: "{{ loadbalancer_limit_nofile | default(100000) }}"
+  notify: restart haproxy
+
+- name: Configure haproxy
+  template:
+    src: haproxy.cfg.j2
+    dest: /etc/haproxy/haproxy.cfg
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart haproxy
+
+- name: Enable and start haproxy
+  systemd:
+    name: haproxy
+    state: restarted
+    enabled: yes
+    daemon_reload: yes
+  register: start_result
+
+- include: iptables.yml
+
+- set_fact:
+    haproxy_start_result_changed: "{{ start_result | changed }}"
+

--- a/ansible/roles/lb/templates/haproxy.cfg.j2
+++ b/ansible/roles/lb/templates/haproxy.cfg.j2
@@ -1,0 +1,66 @@
+# Global settings
+#---------------------------------------------------------------------
+global
+    maxconn     20000
+    log         /dev/log local0 info
+    chroot      /var/lib/haproxy
+    pidfile     /var/run/haproxy.pid
+    user        haproxy
+    group       haproxy
+    daemon
+
+    # turn on stats unix socket
+    stats socket /var/lib/haproxy/stats
+
+#---------------------------------------------------------------------
+# common defaults that all the 'listen' and 'backend' sections will
+# use if not designated in their block
+#---------------------------------------------------------------------
+defaults
+    mode                    http
+    log                     global
+    option                  httplog
+    option                  dontlognull
+#    option http-server-close
+    option forwardfor       except 127.0.0.0/8
+    option                  redispatch
+    retries                 3
+    timeout http-request    10s
+    timeout queue           1m
+    timeout connect         10s
+    timeout client          300s
+    timeout server          300s
+    timeout http-keep-alive 10s
+    timeout check           10s
+    maxconn                 20000
+
+listen stats :9000
+    mode http
+    stats enable
+    stats uri /
+
+frontend  k8s-api-server-frontend
+    bind *:{{ k8s_api_port | default(6443) }}
+    default_backend k8s-api-server-backend
+    mode tcp
+    option tcplog
+
+backend k8s-api-server-backend
+    balance source
+    mode tcp
+{% for host in groups['masters'] %}
+   server {{ hostvars[host]['inventory_hostname'] }} {{ hostvars[host]['ansible_default_ipv4']['address'] }}:{{ k8s_api_port | default(6443) }} check
+{% endfor %}
+
+frontend nuage-k8s-monitor-frontend
+    bind *:{{ nuage_mon_rest_server_port | default(9443) }}
+    default_backend nuage-k8s-monitor-backend
+    mode tcp
+    option tcplog
+
+backend nuage-k8s-monitor-backend
+    balance source
+    mode tcp
+{% for host in groups['masters'] %}
+   server {{ hostvars[host]['inventory_hostname'] }} {{ hostvars[host]['ansible_default_ipv4']['address'] }}:{{ nuage_mon_rest_server_port | default(9443) }} check
+{% endfor %}

--- a/ansible/roles/nuage-common/defaults/main.yml
+++ b/ansible/roles/nuage-common/defaults/main.yml
@@ -15,6 +15,6 @@ nuage_mon_config_dir: /usr/share/nuagekubemon
 nuage_kubeconfig: "{{ nuage_mon_config_dir }}/nuage.kubeconfig"
 nuage_node_kubeconfig: "{{ nuage_node_plugin_dir }}/nuage.kubeconfig"
 
-k8s_ca_crt: "{{ kube_ca_crt | default('/etc/kubernetes/pki/ca.pem') }}"
+k8s_ca_crt: "{{ kube_ca_crt | default('/etc/kubernetes/pki/ca.crt') }}"
 k8s_api_port: "{{ kube_master_api_port | default('6443')}}"
 cert_validity_period: 3650

--- a/ansible/roles/nuage-master/tasks/serviceaccount.yml
+++ b/ansible/roles/nuage-master/tasks/serviceaccount.yml
@@ -12,6 +12,10 @@
   command: kubectl create -f "{{ nuage_mon_config_dir }}"/nuage-serviceaccount.yaml
   when: "'nuage' not in serviceaccounts.stdout"
 
+- name: Grant cluster admin permissions for nuage service account
+  command: kubectl create clusterrolebinding add-on-cluster-admin   --clusterrole=cluster-admin   --serviceaccount=default:nuage --namespace=default
+  ignore_errors: yes    
+
 - name: Get the nuage service token name
   shell: kubectl get serviceaccounts/nuage -o yaml | grep -o "nuage-token.*"
   register: nuagetokenname

--- a/ansible/roles/nuage-master/templates/nuagekubemon.yaml.j2
+++ b/ansible/roles/nuage-master/templates/nuagekubemon.yaml.j2
@@ -19,7 +19,7 @@ userKeyFile: {{ cert_output_dir }}/{{ vsd_user_key_file | basename }}
 # Location where logs should be saved
 log_dir: {{ nuage_mon_rest_server_logdir }}
 # Monitor rest server paramters
-# Logging level for the nuage openshift monitor
+# Logging level for the nuage monitor
 # allowed options are: 0 => INFO, 1 => WARNING, 2 => ERROR, 3 => FATAL
 logLevel: {{ nuage_mon_log_level }}
 # Parameters related to the nuage monitor REST server

--- a/ansible/roles/nuage-node/tasks/main.yml
+++ b/ansible/roles/nuage-node/tasks/main.yml
@@ -7,10 +7,6 @@
   become: yes
   yum: name=python-pip state=present
 
-- name: Install pykube
-  become: yes
-  pip: name=pykube version=0.13.0
-
 - name: Start iptables-service 
   become: yes
   service: name=iptables state=started

--- a/ansible/roles/nuage-node/templates/vsp-k8s.j2
+++ b/ansible/roles/nuage-node/templates/vsp-k8s.j2
@@ -5,7 +5,7 @@ enterpriseName: {{ enterprise }}
 # Name of the domain in which pods will reside
 domainName: {{ domain }}
 # Name of the VSD user in admin group
-vsdUser: {{ vsduser }}
+vsdUser: {{ vsd_user }}
 # REST server URL 
 nuageMonRestServer: {{ nuage_mon_rest_server_url }}
 # Bridge name for the docker bridge

--- a/ansible/roles/nuage-node/vars/main.yml
+++ b/ansible/roles/nuage-node/vars/main.yml
@@ -2,7 +2,7 @@ vrs_config: /etc/default/openvswitch
 vsp_k8s_dir: /usr/share/vsp-k8s
 nuage_plugin_crt_dir : /usr/share/vsp-k8s
 vsp_k8s_yaml: "{{ vsp_k8s_dir }}/vsp-k8s.yaml"
-nuage_master_cluster_hostname: "{{ groups['masters'][0] }}"
+nuage_master_cluster_hostname: "{{ kubernetes_master_cluster_hostname | default(groups['masters'][0]) }}"
 nuage_mon_rest_server_port: "{{ nuage_monitor_rest_server_port | default('9443') }}"
 nuage_mon_rest_server_url: "https://{{ nuage_master_cluster_hostname }}:{{ nuage_mon_rest_server_port }}"
 docker_bridge: "{{ nuage_docker_bridge | default('docker0') }}"
@@ -18,4 +18,4 @@ nuage_ca_master_plugin_key: "{{ nuage_plugin_rest_client_crt_dir }}/nuageMonClie
 nuage_ca_master_plugin_crt: "{{ nuage_plugin_rest_client_crt_dir }}/nuageMonClient.crt" 
 kubelet_service_file: "/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
 nuage_plugin_kubelet_args: "Environment=\"KUBELET_NETWORK_ARGS=--network-plugin=cni --cni-bin-dir=/usr/bin/ --make-iptables-util-chains=false\""
-kubelet_execstart: "ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_EXTRA_ARGS"
+kubelet_execstart: "ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_EXTRA_ARGS $KUBELET_CGROUP_ARGS"


### PR DESCRIPTION
more ansible changes for HA

Changing the defaults cert extenstion to .crt from .pem

Fix VRS-9185

change vsduser to vsd_user to adhere to ansible yaml syntax

Fix VRS-9220

removing pykube install from nuage node install

Fix VRS-8840

Fix VRS-9305

Fixing typos

make k8s_version optional and assign it a default value

reverting changes and making it simpler